### PR TITLE
add propulsion

### DIFF
--- a/Fish/Assets/scene.tscn
+++ b/Fish/Assets/scene.tscn
@@ -1,10 +1,10 @@
-[gd_scene load_steps=6 format=3 uid="uid://b5trd37lpr1fb"]
+[gd_scene load_steps=8 format=3 uid="uid://b5trd37lpr1fb"]
 
 [ext_resource type="Script" path="res://Scripts/Fish.gd" id="1_7w3xm"]
 
-[sub_resource type="SphereMesh" id="SphereMesh_qfo18"]
+[sub_resource type="SphereShape3D" id="SphereShape3D_03103"]
 
-[sub_resource type="SphereShape3D" id="SphereShape3D_w08lv"]
+[sub_resource type="SphereMesh" id="SphereMesh_cincj"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_v4wvx"]
 size = Vector3(50, 0.1, 1)
@@ -12,37 +12,61 @@ size = Vector3(50, 0.1, 1)
 [sub_resource type="BoxMesh" id="BoxMesh_q7fih"]
 size = Vector3(50, 0.1, 1)
 
+[sub_resource type="BoxShape3D" id="BoxShape3D_8lvut"]
+size = Vector3(1, 5, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_mlydc"]
+size = Vector3(1, 5, 1)
+
 [node name="scene" type="Node3D"]
 
 [node name="Fish" type="RigidBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
 script = ExtResource("1_7w3xm")
 
-[node name="Node3D" type="Node3D" parent="Fish"]
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="Fish/Node3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
-mesh = SubResource("SphereMesh_qfo18")
-
 [node name="CollisionShape" type="CollisionShape3D" parent="Fish"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
-shape = SubResource("SphereShape3D_w08lv")
+shape = SubResource("SphereShape3D_03103")
 
-[node name="CameraRig" type="Marker3D" parent="Fish"]
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Fish"]
+mesh = SubResource("SphereMesh_cincj")
+skeleton = NodePath("")
 
-[node name="Camera" type="Camera3D" parent="Fish/CameraRig"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.69118, 5)
+[node name="CameraRig" type="Marker3D" parent="."]
+
+[node name="Camera" type="Camera3D" parent="CameraRig"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.6, 5)
 projection = 1
 current = true
 size = 15.0
 
-[node name="StaticBody3D" type="StaticBody3D" parent="."]
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D"]
-shape = SubResource("BoxShape3D_v4wvx")
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticBody3D"]
-mesh = SubResource("BoxMesh_q7fih")
-
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 7.59602, 0)
 shadow_enabled = true
+
+[node name="Terrain" type="Node" parent="."]
+
+[node name="Floor" type="StaticBody3D" parent="Terrain"]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Terrain/Floor"]
+shape = SubResource("BoxShape3D_v4wvx")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Terrain/Floor"]
+mesh = SubResource("BoxMesh_q7fih")
+
+[node name="LeftWall" type="StaticBody3D" parent="Terrain"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -13, 2.5, 0)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Terrain/LeftWall"]
+shape = SubResource("BoxShape3D_8lvut")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Terrain/LeftWall"]
+mesh = SubResource("BoxMesh_mlydc")
+
+[node name="RightWall" type="StaticBody3D" parent="Terrain"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 13, 2.5, 0)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Terrain/RightWall"]
+shape = SubResource("BoxShape3D_8lvut")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Terrain/RightWall"]
+mesh = SubResource("BoxMesh_mlydc")

--- a/Fish/Scripts/Fish.gd
+++ b/Fish/Scripts/Fish.gd
@@ -1,9 +1,15 @@
 extends RigidBody3D
 
+var camera
+
+func _ready():
+	camera = get_viewport().get_camera_3d()
+	
 func _input(event):
-	# Mouse in viewport coordinates.
 	if event is InputEventMouseButton and event.is_pressed():
-		apply_force_direction(self, Vector3(0,1,0), 10.0) # Adjust strength as needed
+		var unscaled = camera.project_position(event.position, camera.transform.origin.z) - self.transform.origin
+		var scaled = unscaled.normalized()
+		apply_force_direction(self, scaled, 10.0) # Adjust strength as needed
 
 func apply_force_direction(rigid_body: RigidBody3D, direction: Vector3, strength: float) -> void:
 	var force: Vector3 = direction.normalized() * strength

--- a/Fish/Scripts/Fish.gd
+++ b/Fish/Scripts/Fish.gd
@@ -7,9 +7,13 @@ func _ready():
 	
 func _input(event):
 	if event is InputEventMouseButton and event.is_pressed():
-		var unscaled = camera.project_position(event.position, camera.transform.origin.z) - self.transform.origin
+		var unscaled = self.transform.origin - camera.project_position(event.position, camera.transform.origin.z)
 		var scaled = unscaled.normalized()
 		apply_force_direction(self, scaled, 10.0) # Adjust strength as needed
+
+func _process(delta) -> void:
+	camera.transform.origin.x = self.transform.origin.x
+	camera.transform.origin.y = self.transform.origin.y
 
 func apply_force_direction(rigid_body: RigidBody3D, direction: Vector3, strength: float) -> void:
 	var force: Vector3 = direction.normalized() * strength

--- a/Fish/Scripts/Fish.gd
+++ b/Fish/Scripts/Fish.gd
@@ -1,9 +1,9 @@
 extends RigidBody3D
 
-func _process(delta: float) -> void:
-	if Input.is_action_just_pressed("click"):
+func _input(event):
+	# Mouse in viewport coordinates.
+	if event is InputEventMouseButton and event.is_pressed():
 		apply_force_direction(self, Vector3(0,1,0), 10.0) # Adjust strength as needed
-
 
 func apply_force_direction(rigid_body: RigidBody3D, direction: Vector3, strength: float) -> void:
 	var force: Vector3 = direction.normalized() * strength


### PR DESCRIPTION
This PR modifies the scene and the fish script. Scene hierarchy now looks like this:
![image](https://github.com/ReefGuerard/floppy_fish/assets/36433367/152305fd-0f43-4c57-a97d-7b8c3db855a5)
Camera is no longer parented to "fish" to avoid camera rotating uncontrollably when the "fish" rolls.

This PR adds a propulsion capability to the fish to allow it to be pushed away from the direction of the cursor on click. It also makes this click input handling a reaction to an input event instead of a check during every frame. Finally, it fixes the camera position, but not rotation, to the fish transform.
